### PR TITLE
add vim swap files to gitignore

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,3 +2,5 @@ main
 .vscode
 .env
 .DS_STORE
+.*.swp
+.*.swo


### PR DESCRIPTION
added files ending with:
`.swp`
`.swo`
which are vim swap files.
Reference: http://vimdoc.sourceforge.net/htmldoc/recover.html